### PR TITLE
Android enhancement intent and webView fixes

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -83,27 +83,27 @@ export function generateReturnUrl() {
     }
 
     if (isAndroid() && isFirefox()) {
-        return 'android-intent://org.mozilla.firefox'
+        return 'android-app://org.mozilla.firefox'
     }
 
     if (isAndroid() && isEdge()) {
-        return 'android-intent://com.microsoft.emmx'
+        return 'android-app://com.microsoft.emmx'
     }
 
     if (isAndroid() && isOpera()) {
-        return 'android-intent://com.opera.browser'
+        return 'android-app://com.opera.browser'
     }
 
     if (isAndroid() && isBrave()) {
-        return 'android-intent://com.brave.browser'
+        return 'android-app://com.brave.browser'
     }
 
     if (isAndroid() && isAndroidWebView()) {
-        return 'android-intent://webview'
+        return 'android-app://webview'
     }
 
     if (isAndroid() && isChromeMobile()) {
-        return 'android-intent://com.android.chrome'
+        return 'android-app://com.android.chrome'
     }
 
     return window.location.href
@@ -145,6 +145,15 @@ function isAndroid() {
     return /Android/.test(navigator.userAgent)
 }
 
+function isReactNativeApp() {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    return !!window.ReactNativeWebView
+}
+
 function isAndroidWebView() {
-    return /wv/.test(navigator.userAgent) || /Android.*AppleWebKit/.test(navigator.userAgent)
+    return (
+        /wv/.test(navigator.userAgent) ||
+        (/Android/.test(navigator.userAgent) && isReactNativeApp())
+    )
 }


### PR DESCRIPTION
**1. Fix ReturnUrl schema for android intents**

 This commit addresses the issue with the `ReturnUrl` schema. The change is necessary due to the usage of URI syntax for intents in Android, specifically `android-intent://${packageName}`. However, I encounter an issue as React Native does not provide direct support for sending Intents using this URI syntax. Therefore, the workaround adopted is to use `android-app://${packageName}`, which effectively resolves the issue and ensures proper functionality.

**2. Refine Android WebView detection regex**

This commit addresses an issue with the previous regex used in the `isAndroidWebView` function. The regex `/Android.*AppleWebKit/` for checking the presence of WebView in Android was problematic, as the user agent string of the mobile Chrome browser also includes AppleWebKit. This led to incorrect identification of WebView when used by a mobile Chrome browser.

To resolve this, the regex was replaced with a more accurate approach. Now, the function checks for the presence of `'wv'` in the user agent or, if the user agent contains 'android' and the app is recognized as a React Native WebView app (using the isNativeApp function), it correctly identifies Android WebView.


The `android-app://` schema should work well in a native app, it tested in a native module on Android.

The original Regex is not suitable for WebView definition. For example on Android in the Chrome browser, the following string is contained in the userAgent: `Mozilla/5.0 (Linux; Android 13; sdk_gphone64_arm64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.0.0.0 Mobile Safari/537.36`, which matches the conditions and causes the bug.

In react-native there is an option to test on ReactNativeWebView, so it was added to the conditions. 