### PR TITLE
Handling environments with no localization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@wharfkit/protocol-esr",
     "description": "Abstract methods useful to all ESR-based wallet plugins",
-    "version": "1.5.0",
+    "version": "2.0.0",
     "homepage": "https://github.com/wharfkit/protocol-esr",
     "license": "BSD-3-Clause",
     "main": "lib/protocol-esr.js",

--- a/src/callback.ts
+++ b/src/callback.ts
@@ -7,19 +7,19 @@ export async function waitForCallback(callbackArgs, buoyWs, t): Promise<Callback
 
     if (!callbackResponse) {
         // If the promise was rejected, throw an error
-        throw new Error(callbackResponse.rejected)
+        throw new Error('Empty callback response received')
     }
+
+    // Process the identity request callback payload
+    const payload = JSON.parse(callbackResponse) as CallbackPayload
 
     // If the promise was rejected, throw an error
     if (typeof callbackResponse.rejected === 'string') {
         throw new Error(callbackResponse.rejected)
     }
 
-    // Process the identity request callback payload
-    const payload = JSON.parse(callbackResponse) as CallbackPayload
-
     if (payload.sa === undefined || payload.sp === undefined || payload.cid === undefined) {
-        throw new Error(t('error.cancelled', {default: 'The request was cancelled from Anchor.'}))
+        throw new Error('The request was cancelled.')
     }
 
     return payload


### PR DESCRIPTION
We need this change, because currently this library assumes that:
1. It is used by Anchor.
2. That it is used in an environment where the `t()` localization function.
Both are not things that this library should be assuming and they are making it harder to use it in the web authenticator wallet plugin.